### PR TITLE
Getting raw data file path from magnet.ini

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         ui_multiple_materials(ui_core_loss_predict, st.session_state.n_material)
             
     if function_select == 'Download Raw Data':
-        ui_multiple_materials(ui_download_raw_data, st.session_state.n_material)
+        ui_multiple_materials(ui_download_raw_data, st.session_state.n_material, streamlit_root=STREAMLIT_ROOT)
 
     st.title('MagNet Research Team')
     st.image(Image.open(os.path.join(STREAMLIT_ROOT, 'img', 'magnetteam.jpg')), width=1000)

--- a/app/ui_raw.py
+++ b/app/ui_raw.py
@@ -1,17 +1,16 @@
-import re
-import numpy as np
+import os.path
 import streamlit as st
-from magnet.constants import input_dir
-
 
 from magnet import config
-from magnet.constants import material_names  # , excitations # We don't need "Datasheet"
+from magnet.constants import material_names, input_dir
+
 
 def header(material, excitation):
     s = f'Download Raw Data - {material} Material {excitation} '
     return st.header(s)
 
-def ui_download_raw_data(m):
+
+def ui_download_raw_data(m, streamlit_root):
     st.sidebar.header(f'Information for Material {m}')
     material = st.sidebar.selectbox(f'Material {m}:', material_names)
     excitation = st.sidebar.selectbox(f'Excitation {m}:', ("Sinusoidal", "Triangular-Trapezoidal"))
@@ -19,8 +18,9 @@ def ui_download_raw_data(m):
     # It does not make sense to have "Datasheet", also, Triangular and Trapezoidal are saved into the same zip file
     header(material, excitation)
 
-    file_zip = input_dir + material + "_" + excitation + "_Raw_Data_Short.zip"
-    st.download_button(f'Download ZIP file', open(file_zip, "rb"), material + "_" + excitation + ".zip", "zip", key=m)
+    data_file = os.path.join(streamlit_root, config.data.raw_data_file.format(material=material, excitation=excitation))
+    with open(data_file, 'rb') as file:
+        st.download_button(f'Download Data file', file, os.path.basename(data_file), key=m)
 
     file_txt = input_dir + material + "_" + excitation + "_Test_Info.txt"
     txt_info_file = open(file_txt)

--- a/src/magnet/magnet.ini
+++ b/src/magnet/magnet.ini
@@ -26,6 +26,11 @@ core_loss_flux = [0.010, 0.012, 0.015, 0.017, 0.020, 0.025, 0.03, 0.04, 0.05, 0.
 # Duty values for which we plot core loss
 core_loss_duty = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
+[data]
+# Absolute or relative (to STREAMLIT_ROOT) path pattern where we can find the raw data
+# The pattern SHOULD contain {material} and {excitation} as placeholders.
+raw_data_file = "../../data/{material}_{excitation}_Raw_Data_Short.zip"
+
 [test]
 # This section is exclusively for pytest testing.
 # Any modifications here should mirror what's being tested in tests/test_config.py


### PR DESCRIPTION
This approach puts the path to the raw data in `magnet.ini`, making it easily modifiable in the future. I've also removed unused imports and some comments (comments in code that have to do with future TODOs, or commented-out code tends to fossilize and gets in the way of understanding).

Note that `src/` folder is not the correct place for raw data, as this folder should ideally be reserved for anything that you want to be installed on the client's computer through a `pip install` (what gets installed can further be finely-controlled through `MANIFEST.in`).

There will be another PR later to completely remove the notion of `input_dir`.

Please review and merge this since `develop` is under heavy modification nowadays - however, tomorrow I might send another small PR after modifying the ini file to indicate the final resting place of the raw data on the server.