### PR TITLE
Correct location of raw data files on server

### DIFF
--- a/app/ui_raw.py
+++ b/app/ui_raw.py
@@ -23,7 +23,7 @@ def ui_download_raw_data(m, streamlit_root):
 
     header(material, excitation)
 
-    data_file = os.path.join(streamlit_root, config.data.raw_data_file.format(material=material, excitation=read_excitation))
+    data_file = os.path.join(streamlit_root, config.streamlit.raw_data_file.format(material=material, excitation=read_excitation))
     with open(data_file, 'rb') as file:
         st.download_button(f'Download Data file', file, os.path.basename(data_file), key=m)
 

--- a/src/magnet/magnet.ini
+++ b/src/magnet/magnet.ini
@@ -34,10 +34,9 @@ core_loss_flux = [0.010, 0.012, 0.015, 0.017, 0.020, 0.025, 0.03, 0.04, 0.05, 0.
 # Duty values for which we plot core loss
 core_loss_duty = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
-[data]
 # Absolute or relative (to STREAMLIT_ROOT) path pattern where we can find the raw data
 # The pattern SHOULD contain {material} and {excitation} as placeholders.
-raw_data_file = "../../data/{material}_{excitation}_Raw_Data_Short.zip"
+raw_data_file = "/usr/local/share/magnet-data/{material}_{excitation}_Raw_Data_Short.zip"
 
 [test]
 # This section is exclusively for pytest testing.


### PR DESCRIPTION
A couple more minor changes:
- Correct location of data files on server.
- There was really no need for a separate `data` section in the `.ini` file (as I had done originally). The `streamlit` section would work just fine, and is preferable since this is a streamlit-specific setting after all. Changed now.