### PR TITLE
enabling release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,4 +67,3 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-      if: false


### PR DESCRIPTION
Now that we have access to the magnet [PyPI](https://pypi.org/project/mag-net/) repository, I'm re-enabling the automatic release process for magnet. I can demo how this can be used in the future.