### PR TITLE
Fix for displaying frequency and B field range in MagNet Database page

### DIFF
--- a/app/ui_db.py
+++ b/app/ui_db.py
@@ -166,8 +166,8 @@ def ui_core_loss_db(m):
         st.title(f'Core Loss Database: Case {m}')
         st.subheader(f'{material_manufacturers[material]} - {material}, '
                      f'{excitation} excitation')
-        st.subheader(f'f=[{round(freq_min / 1e3)}~{round(freq_max / 1e3)}] kHz, '
-                     f'B=[{round(flux_min * 1e3)}~{round(flux_max * 1e3)}] mT, '
+        st.subheader(f'f=[{round(freq_min / 1e3)}-{round(freq_max / 1e3)}] kHz, '
+                     f'B=[{round(flux_min * 1e3)}-{round(flux_max * 1e3)}] mT, '
                      f'Bias={round(flux_bias * 1e3)} mT')
         if excitation == "Triangular":
             st.subheader(f'D={round(duty_p, 2)}')


### PR DESCRIPTION
In ui_db.py, a "~" character inserted into the formatted string for displaying the frequency and B field range of the data sample unintentionally formats to strikethrough text, as shown in the screenshot below.

![2022-08-04_23-59_1](https://user-images.githubusercontent.com/59377837/182999526-1900833d-fc74-4913-a5cb-6bc01f705547.png)

Simply replaced the "~" character with "-" to denote a range of values.

![2022-08-04_23-59](https://user-images.githubusercontent.com/59377837/182999535-4b4b9187-1ba0-42d3-91c3-e10b1e724e2d.png)

Assuming that the fix shows the expected behavior of this page.