### PR TITLE
Add auto phase adjustment

### DIFF
--- a/src/magnet/magnet.ini
+++ b/src/magnet/magnet.ini
@@ -16,7 +16,7 @@ n_nn = 128
 n_points_plot = 101
 
 # Frequencies for which we plot core loss
-core_loss_freq = [50000, 70000, 100000, 200000, 500000, 700000, 1000000]
+core_loss_freq = [50000, 75000, 100000, 200000, 300000, 400000, 500000]
 # Flux values for which we plot core loss
 core_loss_flux = [0.01, 0.02, 0.03, 0.05, 0.07, 0.10, 0.2, 0.3]
 # Duty values for which we plot core loss
@@ -24,7 +24,7 @@ core_loss_duty = [0.1, 0.2, 0.3, 0.5, 0.7, 0.8, 0.9]
 # Bias values for which we plot core loss
 core_loss_bias = [0, 30, 45, 60, 75]
 # Temperatures for which we plot core loss
-core_loss_temp = [25, 50, 70, 90, 120]
+core_loss_temp = [25, 35, 50, 75, 95]
 
 # Absolute or relative (to STREAMLIT_ROOT) path pattern where we can find the raw data
 # The pattern SHOULD contain {material} and {excitation} as placeholders.


### PR DESCRIPTION
Note:

In the `AI` session, the `Phase` is a variable that can be controlled by users. It is observed that the predicted results deviate a lot in such `Phase` values that sharp transitions happen at the beginning or the ending of the sequence from those in other `Phase` values.

Previously, in the `Smartsheet` session, however, the `Phase` is always by default set as zero, resulting in that the aforementioned deviation always exists, leading to the unreasonable core loss curves. Therefore, an automatic adjustment of `Phase` is implemented for all the predictions in the `Smartsheet` session, to make sure any sharp transitions always happen at the middle part of the sequence. This solved the issue to some extent.

Nevertheless, unreliable results are still generated due to extrapolations when the variables are out of range. For example, 3C90 with 50kHz 50mT D=0.1 triangular wave at 25C and 0 dc bias. I would suggest further constraining the range, or putting a warning of extrapolation for figures (currently there are only warnings for sliders).