### PR TITLE
Develop

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 import os.path
 from PIL import Image
 import streamlit as st
+st.set_page_config(page_title='MagNet', page_icon="⚡", layout='wide')
 #import streamlit_analytics
 
 from magnet import __version__
@@ -37,8 +38,6 @@ def contributor(name, email):
  
 if __name__ == '__main__':
     
-
-    st.set_page_config(page_title='MagNet', page_icon="⚡", layout='wide')
     st.sidebar.image(Image.open(os.path.join(STREAMLIT_ROOT, 'img', 'magnetlogo.jpg')), width=300)
     st.sidebar.markdown('[GitHub](https://github.com/PrincetonUniversity/Magnet) | [Doc](https://princetonuniversity.github.io/magnet/) | [Report an Issue](https://github.com/PrincetonUniversity/magnet/issues) ')
     st.sidebar.markdown('[Princeton Power Electronics Lab](https://www.princeton.edu/~minjie/)')

--- a/app/main.py
+++ b/app/main.py
@@ -37,7 +37,7 @@ def contributor(name, email):
  
 if __name__ == '__main__':
     
-    st.set_page_config(page_title='MagNet', layout='wide')
+    st.set_page_config(page_title='MagNet', page_icon="⚡", layout='wide')
     st.sidebar.image(Image.open(os.path.join(STREAMLIT_ROOT, 'img', 'magnetlogo.jpg')), width=300)
     st.sidebar.markdown('[GitHub](https://github.com/PrincetonUniversity/Magnet) | [Doc](https://princetonuniversity.github.io/magnet/) | [Report an Issue](https://github.com/PrincetonUniversity/magnet/issues) ')
     st.sidebar.markdown('[Princeton Power Electronics Lab](https://www.princeton.edu/~minjie/)')

--- a/app/main.py
+++ b/app/main.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
         ui_multiple_materials(ui_core_loss_predict, st.session_state.n_material)
         
     if function_select == 'MagNet Simulation':
-        st.title('MagNet Simulation for Circuit Analysis [pending]')
+        st.title('MagNet Simulation for Circuit Analysis')
         ui_multiple_materials(SimulationPLECS)
         st.session_state.n_material = 1  # Resets the number of plots
             

--- a/scripts/cron.sh
+++ b/scripts/cron.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Invoked regularly in a crontab
+# with parameters (1) Conda env name, (2) Streamlit base directory
+# ---------- 
+# crontab -e
+# ---------- 
+# SHELL=/bin/bash
+# BASH_ENV=/path/to/file/with/contents/of/conda/init
+# 0 * * * * bash /path/to/this/script <dev_conda_env> /path/to/dev/streamlit
+# 0 * * * 7 bash /path/to/this/script <prod_conda_env> /path/to/prod/streamlit
+# ----------
+
+CONDA_ENV=$1
+STREAMLIT_DIR=$2
+STREAMLIT_CMD="python -m streamlit run app/main.py" 
+
+eval "$(conda shell.bash hook)"
+conda activate ${CONDA_ENV}
+cd ${STREAMLIT_DIR}
+echo "${CONDA_PREFIX}"
+git pull
+# No need to reinstall the package since its initially installed
+# in development mode anyway. This means we won't be up-to-date
+# with the dependencies, so we'll handle that offline as and when
+# the dependencies change.
+# pip install -e .
+
+# The following commented-out block is the rather drastic (formerly used)
+# step of killing the streamlit process and starting it again.
+# Besides being disruptive, recent versions of streamlit seem to monitor
+# changes in the 'magnet' package and reflect them immediately, so none of this
+# is needed.
+: '
+echo "Checking for running streamlit processes with CWD=${STREAMLIT_DIR}"
+
+PIDS=`ps -ef | grep "${STREAMLIT_CMD}" | grep -v grep | tr -s ' ' | cut -d ' ' -f 2`
+for PID in $PIDS; do
+    PID_WD=`pwdx ${PID} | cut -d ' ' -f 2`
+    if [ "$PID_WD" = "$STREAMLIT_DIR" ]; then
+      echo "Found PID ${PID}. Trying to stop .."
+      kill ${PID}
+    fi
+done
+
+echo "Re-running command .."
+eval "${STREAMLIT_CMD}" &>/dev/null & disown;
+'
+
+conda deactivate
+
+# Start PLECS if not running 
+
+# "PLECS_server -v" returns with an exit code of 0 whether its running or not
+# so we check its stdout instead.
+if /opt/plecs/PLECS_server -v | grep -q 'not running'; then
+  /opt/plecs/PLECS_server
+fi


### PR DESCRIPTION
I noticed that intermittently (locally as well as on the server), everytime there is a local file change, I would get a:

```
streamlit.errors.StreamlitAPIException: `set_page_config()` can only be called once per app, and must be called as the first Streamlit command in your script.
```

The `set_page_config` call seems really the first one to be executed anyway, but in any case, moving it further up right after the `import streamlit as st` makes the error go away. I can't explain it, but it seems like a safe thing to do.

I've also added the `cron.sh` script that we use on the server as part of the `scripts/` folder, so it doesn't get lost. Recent changes to this `cron.sh` reflect the tweaks we have made to not kill/restart the server periodically, but do things a bit more gracefully.