### PR TITLE
fixes "not_extrapolated" variable reference due to not being assigned in arbitary excitation case

### DIFF
--- a/app/ui_predict.py
+++ b/app/ui_predict.py
@@ -230,7 +230,7 @@ def ui_core_loss_predict(m):
     # Variables that are function of the sliders, different type depending on the excitation
 
     if excitation == 'Arbitrary':
-        loss = core_loss_arbitrary(material, freq, flux_vector, temp, bias, duty_vector)
+        loss, not_extrapolated = core_loss_arbitrary(material, freq, flux_vector, temp, bias, duty_vector)
     else:
         loss, not_extrapolated = core_loss_default(material, freq, flux, temp, bias, duty, batched = False)
 

--- a/src/magnet/core.py
+++ b/src/magnet/core.py
@@ -113,7 +113,9 @@ def core_loss_arbitrary(material, freq, flux, temp, bias, duty):
     bdata = bdata_pre - np.average(bdata_pre)
     hdata = BH_Transformer(material, freq, temp, bias, bdata)
     core_loss = loss_BH(bdata, hdata, freq)
-    return core_loss
+    not_extrapolated = [False for i in range(len(bdata))]
+
+    return core_loss, not_extrapolated
 
 
 def BH_Transformer(material, freq, temp, bias, bdata):


### PR DESCRIPTION
UnboundLocalError: local variable 'not_extrapolated' referenced before assignment in SmartSheet for Arbitary Excitation due differences in output by two similar func.

