### PR TITLE
Fixed change of dphi/dt to dB/dt in plecs models. Area was fixed.

### DIFF
--- a/src/magnet/simplecs/models/Boost.plecs
+++ b/src/magnet/simplecs/models/Boost.plecs
@@ -1052,7 +1052,7 @@ Plecs {
       Flipped       on
       Parameter {
         Variable      "K"
-        Value         "1/(676e-6*2)"
+        Value         "1/(Ac)"
         Show          off
       }
       Parameter {

--- a/src/magnet/simplecs/models/Buck.plecs
+++ b/src/magnet/simplecs/models/Buck.plecs
@@ -1052,7 +1052,7 @@ Plecs {
       Flipped       on
       Parameter {
         Variable      "K"
-        Value         "1/(676e-6*2)"
+        Value         "1/(Ac)"
         Show          off
       }
       Parameter {

--- a/src/magnet/simplecs/models/DAB.plecs
+++ b/src/magnet/simplecs/models/DAB.plecs
@@ -1069,7 +1069,7 @@ Plecs {
       Flipped       on
       Parameter {
         Variable      "K"
-        Value         "1/(676e-6*2)"
+        Value         "1/(Ac)"
         Show          off
       }
       Parameter {

--- a/src/magnet/simplecs/models/Flyback.plecs
+++ b/src/magnet/simplecs/models/Flyback.plecs
@@ -1052,7 +1052,7 @@ Plecs {
       Flipped       on
       Parameter {
         Variable      "K"
-        Value         "1/(676e-6*2)"
+        Value         "1/(Ac)"
         Show          off
       }
       Parameter {


### PR DESCRIPTION
I debugged with printing **self.Ploss in steadyRun function**. The volumetric loss [On website] was not matching Ploss from IGSE computed by Plecs by a large margin[Plecs computation was off due to fixed area]. It is now close

Note: it appears that it is used not anywhere so it was not affecting any  values put out by MagNet, but this fixes that!