### PR TITLE
Integrates mag-net-hub fork with magnet ui-intro.py models

### DIFF
--- a/app/ui_intro.py
+++ b/app/ui_intro.py
@@ -22,7 +22,9 @@ def ui_intro(m):
     st.subheader('"It is time to upgrade the Steinmetz Equation!" - Try MagNet AI and join us to make it better')
     st.caption('We created MagNet AI to advance power magnetics research, education, and design. The mission of MagNet AI is to replace the traditional curve-fitting models (e.g., Steinmetz Equations and Jiles-Atherton Models) with state-of-the-art data-driven methods such as neural networks and machine learning. MagNet AI is open, transparent, fast, smart, versatile, and is continously learning. It is a new tool to design power magnetics and can do lots of things that traditional methods cannnot do.')
     st.markdown("""---""")
-    model_list=['magnet',"asu","paderborn","sydney"]
+    mag_net_hub_models=list(mh.loss.TEAMS.keys())
+
+    model_list=['magnet']+mag_net_hub_models
     col1, col2 = st.columns(2)
     with col1:
         st.header('MagNet AI Input')
@@ -244,7 +246,7 @@ def ui_intro(m):
             if flag_dbdt_high == 1:
                 st.warning(f"For dB/dt above {round(dbdt_max * 1e-3)} mT/ns, results are potentially extrapolated.")
     
-    if model in ['paderborn',"sydney","asu"]:
+    if model in mag_net_hub_models:
         mdl = mh.loss.LossModel(material=material, team=model)
         loss, hdata = mdl(resample(bdata,1024), freq, temp)
     else:
@@ -364,11 +366,10 @@ def ui_intro(m):
     
         loss_test_list = pd.DataFrame(columns=['Material','Core Loss [kW/m^3]','This one'])
         for material_test in material_list:
-            if model in ['paderborn',"sydney","asu"]:
+            if model in mag_net_hub_models:
                 mdl = mh.loss.LossModel(material=material_test, team=model)
                 loss_test, hdata_test = mdl(resample(bdata,1024), freq, temp)
                 loss_test=np.round(loss_test,2)
-                print(loss_test.shape)
             else:
                 hdata_test = BH_Transformer(material_test, freq, temp, bias, bdata)
                 loss_test = loss_BH(bdata, hdata_test, freq)

--- a/app/ui_intro.py
+++ b/app/ui_intro.py
@@ -9,7 +9,6 @@ import numpy as np
 from magnet.core import BH_Transformer, loss_BH, bdata_generation, point_in_hull
 from magnet import config as c
 import magnethub as mh
-from scipy.signal import resample
 
 STREAMLIT_ROOT = os.path.dirname(__file__)
 
@@ -248,7 +247,7 @@ def ui_intro(m):
     
     if model in mag_net_hub_models:
         mdl = mh.loss.LossModel(material=material, team=model)
-        loss, hdata = mdl(resample(bdata,1024), freq, temp)
+        loss, hdata = mdl(bdata, freq, temp)
     else:
         hdata = BH_Transformer(material, freq, temp, bias, bdata)
         loss = loss_BH(bdata, hdata, freq)
@@ -368,7 +367,7 @@ def ui_intro(m):
         for material_test in material_list:
             if model in mag_net_hub_models:
                 mdl = mh.loss.LossModel(material=material_test, team=model)
-                loss_test, hdata_test = mdl(resample(bdata,1024), freq, temp)
+                loss_test, hdata_test = mdl(bdata, freq, temp)
                 loss_test=np.round(loss_test,2)
             else:
                 hdata_test = BH_Transformer(material_test, freq, temp, bias, bdata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "streamlit==1.1.0",
     "streamlit-analytics",
     "tables==3.6.1",
-    "torch==1.9.0"
+    "torch==1.9.0",
+    "git+https://github.com/ehavugi/mag-net-hub.git"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Integrates mag-net-hub fork with magnet ui-intro.py models

related https://github.com/upb-lea/mag-net-hub/discussions/1
**Key changes** upsampling 128 to 1024 points
```
 for material_test in material_list:
            if model in mag_net_hub_models:
                mdl = mh.loss.LossModel(material=material_test, team=model)
                loss_test, hdata_test = mdl(resample(bdata,1024), freq, temp)
                loss_test=np.round(loss_test,2)
            else:
                hdata_test = BH_Transformer(material_test, freq, temp, bias, bdata)
                loss_test = loss_BH(bdata, hdata_test, freq)

```

For the displayed H, currently the magnet(princeton) H prediction is not overrided due to possibility of not having H in a mag-net-hub model. 

